### PR TITLE
Create did

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ dist
 
 # TernJS port file
 .tern-port
+
+# Jungle Testnet keymaterial
+jungleTestKeys.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -2074,6 +2074,29 @@
       "integrity": "sha512-p68+a+KoxpoB47015IeYZYRrdqMUcpbK8re/zpFB8Ld46LHC1lPEbp3EXgkEhAYEcPvjJF6ZO+869SQ0aH1dcA==",
       "dev": true
     },
+    "@types/node-fetch": {
+      "version": "2.5.10",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.10.tgz",
+      "integrity": "sha512-IpkX0AasN44hgEad0gEF/V6EgR5n69VEqPEgnmoM8GsIGro3PowbWs4tR6IhxUTyPLpOn+fiGG6nrQhcmoCuIQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+          "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
     "@types/normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
@@ -3170,8 +3193,7 @@
     "bn.js": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
-      "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==",
-      "dev": true
+      "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
     },
     "boolbase": {
       "version": "1.0.0",
@@ -3221,8 +3243,7 @@
     "brorand": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
-      "dev": true
+      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
     },
     "browser-process-hrtime": {
       "version": "1.0.0",
@@ -4602,7 +4623,6 @@
       "version": "6.5.4",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
       "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
-      "dev": true,
       "requires": {
         "bn.js": "^4.11.9",
         "brorand": "^1.1.0",
@@ -4616,8 +4636,7 @@
         "bn.js": {
           "version": "4.12.0",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
-          "dev": true
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
         }
       }
     },
@@ -4679,6 +4698,24 @@
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
       "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
       "dev": true
+    },
+    "eosjs": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/eosjs/-/eosjs-22.0.0.tgz",
+      "integrity": "sha512-zwNtpcFo58whTve6A+jnaYKMUBVMezY8E4dRuRi7eakvrai6CXpVEMshyX9GlalzjQXoI0UjrY4EM6K0LmbgZg==",
+      "requires": {
+        "bn.js": "5.2.0",
+        "elliptic": "6.5.4",
+        "hash.js": "1.1.7",
+        "pako": "2.0.3"
+      },
+      "dependencies": {
+        "pako": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/pako/-/pako-2.0.3.tgz",
+          "integrity": "sha512-WjR1hOeg+kki3ZIOjaf4b5WVcay1jaliKSYiEaB1XzwhMQZJxRdQRv0V31EKBYlxb4T7SK3hjfc/jxyU64BoSw=="
+        }
+      }
     },
     "errno": {
       "version": "0.1.8",
@@ -6136,7 +6173,6 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
       "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
-      "dev": true,
       "requires": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
@@ -6152,7 +6188,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
-      "dev": true,
       "requires": {
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
@@ -6356,8 +6391,7 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "inquirer": {
       "version": "7.3.3",
@@ -9041,14 +9075,12 @@
     "minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
-      "dev": true
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
     },
     "minimalistic-crypto-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
-      "dev": true
+      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -9214,6 +9246,11 @@
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
       }
+    },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "node-int64": {
       "version": "0.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3129,6 +3129,11 @@
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
       "dev": true
     },
+    "base64url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
+      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="
+    },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -4698,6 +4703,33 @@
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
       "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
       "dev": true
+    },
+    "eosio-did-resolver": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/eosio-did-resolver/-/eosio-did-resolver-0.1.3.tgz",
+      "integrity": "sha512-i9rnWoN7hJkYw902VXLdXy6X90x/mksCCitC6OjdM2Gl4iqCF2WBZxkwDFdxeszvwCrHElj5MbGw042flJaHOg==",
+      "requires": {
+        "base64url": "^3.0.1",
+        "eosjs": "^21.0.4"
+      },
+      "dependencies": {
+        "eosjs": {
+          "version": "21.0.4",
+          "resolved": "https://registry.npmjs.org/eosjs/-/eosjs-21.0.4.tgz",
+          "integrity": "sha512-XbuIoidplA1hHIejy7VQ+hmBfC6T28kYFaQMsn6G1DMTg1CFwUzxwzUvZg/dGNPuf7hgPxOpaQvAUsdidTgGhQ==",
+          "requires": {
+            "bn.js": "5.2.0",
+            "elliptic": "6.5.4",
+            "hash.js": "1.1.7",
+            "pako": "2.0.3"
+          }
+        },
+        "pako": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/pako/-/pako-2.0.3.tgz",
+          "integrity": "sha512-WjR1hOeg+kki3ZIOjaf4b5WVcay1jaliKSYiEaB1XzwhMQZJxRdQRv0V31EKBYlxb4T7SK3hjfc/jxyU64BoSw=="
+        }
+      }
     },
     "eosjs": {
       "version": "22.0.0",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
   },
   "dependencies": {
     "did-resolver": "^3.1.0",
+    "eosio-did-resolver": "^0.1.3",
     "eosjs": "^22.0.0",
     "node-fetch": "^2.6.1"
   }

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   ],
   "devDependencies": {
     "@size-limit/preset-small-lib": "^4.10.2",
+    "@types/node-fetch": "^2.5.10",
     "husky": "^6.0.0",
     "size-limit": "^4.10.2",
     "tsdx": "^0.14.1",
@@ -63,6 +64,8 @@
     "typescript": "^4.2.4"
   },
   "dependencies": {
-    "did-resolver": "^3.1.0"
+    "did-resolver": "^3.1.0",
+    "eosjs": "^22.0.0",
+    "node-fetch": "^2.6.1"
   }
 }

--- a/src/create.ts
+++ b/src/create.ts
@@ -51,7 +51,7 @@ export default async function create(
       stakeCpuQuantity: '1.0000 EOS',
       transfer: false,
     },
-    configurationObject: {
+    config: {
       blocksBehind: 3,
       expireSeconds: 30,
     },
@@ -120,11 +120,16 @@ export default async function create(
             },
           ],
         },
-        additionalOptions.configurationObject
+        additionalOptions.config
       );
+
       console.dir(result);
-      // TODO: convert transaction result to did document
-      return { id: 'did:eosio:stub' };
+
+      // TODO: create the complete DIDDocument
+      return {
+        '@context': ['https://www.w3.org/ns/did/v1'],
+        id: 'did:eosio:' + chain + ':' + name,
+      };
     } catch (e) {
       if (
         !(e instanceof FetchError) ||

--- a/src/create.ts
+++ b/src/create.ts
@@ -1,12 +1,173 @@
-import { DIDDocument } from "did-resolver";
-import { Authority, ConfigOptions } from "./types";
+import { DIDDocument } from 'did-resolver';
+import { Authority, ConfigOptions } from './types';
+import fetch, { FetchError } from 'node-fetch';
+import { JsonRpc, Api } from 'eosjs';
+import { SignatureProvider } from 'eosjs/dist/eosjs-api-interfaces';
+import { TextEncoder, TextDecoder } from 'util';
+
+// TODO: import the chain-registry from the resolver npm package.
+const defaultChainRegistry: ConfigOptions = {
+  'eos:testnet:jungle': {
+    chainId: '2a02a0053e5a8cf73a56ba0fda11e4d92e0238a4a2aa74fccf46d5a910746840',
+    service: [
+      {
+        id: 'https://jungle3.cryptolions.io',
+        type: 'LinkedDomains',
+        serviceEndpoint: 'https://jungle3.cryptolions.io',
+      },
+    ],
+  },
+};
+
+const ACCOUNT_NAME = `^([a-z1-5.]{0,12}[a-z1-5])$`;
+const CHAIN_ID = new RegExp(`^([A-Fa-f0-9]{64})$`);
+const CHAIN_NAME = new RegExp(
+  `^(([a-z1-5.]{0,12}[a-z1-5])((:[a-z1-5.]{0,12}[a-z1-5])+)?)$`
+);
 
 export default async function create(
-    creator: string,
-    name: string,
-    owner: Authority,
-    active: Authority,
-    options?: ConfigOptions): Promise<DIDDocument> {
+  chain: string,
+  creator: string,
+  name: string,
+  owner: Authority,
+  active: Authority,
+  signatureProvider: SignatureProvider,
+  options?: ConfigOptions
+): Promise<DIDDocument> {
+  // the user may want to override these values.
+  const additionalOptions = {
+    receiverAccount: 'eosio',
+    authorization: [
+      {
+        actor: creator,
+        permission: 'active',
+      },
+    ],
+    buyrambytes: {
+      bytes: 8192,
+    },
+    delegatebw: {
+      stakeNetQuantity: '1.0000 EOS',
+      stakeCpuQuantity: '1.0000 EOS',
+      transfer: false,
+    },
+    configurationObject: {
+      blocksBehind: 3,
+      expireSeconds: 30,
+    },
+  };
 
-    return { id: 'did:eosio:stub' };
+  validateAccountName(creator);
+  validateAccountName(name);
+
+  const chainRegistry = {
+    ...defaultChainRegistry,
+    ...options,
+  };
+
+  const chainData = getChainData(chainRegistry, chain);
+
+  let fetchAttempts = 0;
+  for (const service of chainData.service) {
+    fetchAttempts++;
+
+    const rpc = new JsonRpc(service.serviceEndpoint, { fetch });
+    const api = new Api({
+      rpc: rpc,
+      signatureProvider,
+      textDecoder: new TextDecoder() as any,
+      textEncoder: new TextEncoder(),
+    });
+
+    try {
+      const result = await api.transact(
+        {
+          actions: [
+            {
+              account: additionalOptions.receiverAccount,
+              name: 'newaccount',
+              authorization: additionalOptions.authorization,
+              data: {
+                creator: creator,
+                name: name,
+                owner: owner,
+                active: active,
+              },
+            },
+            {
+              account: additionalOptions.receiverAccount,
+              name: 'buyrambytes',
+              authorization: additionalOptions.authorization,
+              data: {
+                payer: creator,
+                receiver: name,
+                bytes: additionalOptions.buyrambytes.bytes,
+              },
+            },
+            {
+              account: additionalOptions.receiverAccount,
+              name: 'delegatebw',
+              authorization: additionalOptions.authorization,
+              data: {
+                from: creator,
+                receiver: name,
+                stake_net_quantity:
+                  additionalOptions.delegatebw.stakeNetQuantity,
+                stake_cpu_quantity:
+                  additionalOptions.delegatebw.stakeNetQuantity,
+                transfer: additionalOptions.delegatebw.transfer,
+              },
+            },
+          ],
+        },
+        additionalOptions.configurationObject
+      );
+      console.dir(result);
+      // TODO: convert transaction result to did document
+      return { id: 'did:eosio:stub' };
+    } catch (e) {
+      if (
+        !(e instanceof FetchError) ||
+        fetchAttempts >= chainData.service.length
+      )
+        throw e;
+
+      // else: continue with remaining service endpoints
+    }
+  }
+
+  throw new Error('Could not create DID.');
+}
+
+function getChainData(chainRegistry: ConfigOptions, chainId: string) {
+  // findChainByName
+  const partsName = chainId.match(CHAIN_NAME);
+  if (partsName) {
+    const entry = chainRegistry[partsName[1]];
+    if (entry) return entry;
+    throw new Error(
+      'No matching chain registry entry for supplied chain name.'
+    );
+  }
+
+  // findChainById
+  const partsID = chainId.match(CHAIN_ID);
+  if (partsID) {
+    for (let key of Object.keys(chainRegistry)) {
+      const entry = chainRegistry[key];
+      if (entry.chainId === partsID[1]) return entry;
+      throw new Error(
+        'No matching chain registry entry for supplied chain id.'
+      );
+    }
+  }
+
+  throw new Error(
+    'Supplied chain id or name does not conform to specification.'
+  );
+}
+
+function validateAccountName(name: string) {
+  if (name.match(ACCOUNT_NAME) === null)
+    throw new Error(name + ' does not conform to account name specification.');
 }

--- a/src/deactivate.ts
+++ b/src/deactivate.ts
@@ -1,8 +1,8 @@
-import { ConfigOptions } from "./types";
+import { ConfigOptions } from './types';
 
 export default async function deactivate(
-    did: string,
-    options?: ConfigOptions): Promise<void> {
-
-    throw Error('EOSIO DID deactivate not supported');
+  did: string,
+  options?: ConfigOptions
+): Promise<void> {
+  throw Error('EOSIO DID deactivate not supported');
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,11 +4,8 @@ import update from './update';
 import deactivate from './deactivate';
 import { ConfigOptions, EosioDIDInterface } from './types';
 
-
 export default class EosioDID implements EosioDIDInterface {
-  constructor(options?: ConfigOptions) {
-
-  }
+  constructor(options?: ConfigOptions) {}
 
   create = create;
   resolve = resolve;
@@ -16,9 +13,4 @@ export default class EosioDID implements EosioDIDInterface {
   deactivate = deactivate;
 }
 
-export {
-  create,
-  resolve,
-  update,
-  deactivate
-}
+export { create, resolve, update, deactivate };

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,12 +2,35 @@ import create from './create';
 import resolve from './resolve';
 import update from './update';
 import deactivate from './deactivate';
-import { ConfigOptions, EosioDIDInterface } from './types';
+import { ConfigOptions, EosioDIDInterface, Authority } from './types';
+import { SignatureProvider } from 'eosjs/dist/eosjs-api-interfaces';
+import { DIDDocument } from 'did-resolver';
 
 export default class EosioDID implements EosioDIDInterface {
-  constructor(options?: ConfigOptions) {}
+  options: ConfigOptions;
+  constructor(options: ConfigOptions = {}) {
+    this.options = options;
+  }
 
-  create = create;
+  async create(
+    chain: string,
+    creator: string,
+    name: string,
+    owner: Authority,
+    active: Authority,
+    signatureProvider: SignatureProvider,
+    options?: ConfigOptions
+  ): Promise<DIDDocument> {
+    return await create(
+      chain,
+      creator,
+      name,
+      owner,
+      active,
+      signatureProvider,
+      { ...this.options, ...options }
+    );
+  }
   resolve = resolve;
   update = update;
   deactivate = deactivate;

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -1,9 +1,9 @@
-import { DIDDocument } from "did-resolver";
-import { ConfigOptions } from "./types";
+import { DIDDocument } from 'did-resolver';
+import { ConfigOptions } from './types';
 
 export default async function resolve(
-    did: string,
-    options?: ConfigOptions): Promise<DIDDocument> {
-
-    return { id: 'did:eosio:stub' };
+  did: string,
+  options?: ConfigOptions
+): Promise<DIDDocument> {
+  return { id: 'did:eosio:stub' };
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -12,6 +12,31 @@ export declare type ConfigOptions = {
     }
 }
 
+// export declare type ConfigOptions = {
+//     registry?: ChainRegistry,
+//     authorization?: [
+//         {
+//           actor: string,
+//           permission: string,
+//         },
+//     ], 
+//     create?: {
+//         buyrambytes?: {
+//           bytes: number,
+//         },
+//         delegatebw?: {
+//           stakeNetQuantity?: string,
+//           stakeCpuQuantity?: string,
+//           transfer?: boolean,
+//         },
+//     },
+//     config?: {
+//         blocksBehind?: number,
+//         expireSeconds?: number,
+//     },
+//     [x: string]: any
+// }
+
 export declare type Authority = {
     threshold: number,
     keys?: [{

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,11 +1,12 @@
 import { DIDDocument } from 'did-resolver';
+import { SignatureProvider } from 'eosjs/dist/eosjs-api-interfaces';
 
 export declare type ConfigOptions = {
     [x: string]: {
         chainId: string,
         service: [{
             id: string,
-            type: [string],
+            type: string | [string],
             serviceEndpoint: string
         }]
     }
@@ -17,21 +18,21 @@ export declare type Authority = {
         key: string,
         weight: number
     }],
-    accounts?: [{
+    accounts: [] | [{
         permission: {
             actor: string,
             permission: string
         },
         weight: number
     }],
-    waits?: [{
+    waits: [] | [{
         wait_sec: number,
         wait: number
     }]
 }
 
 export declare interface EosioDIDInterface {
-    async create(creator: string, name: string, owner: Authority, active: Authority, options?: ConfigOptions): Promise<DIDDocument>;
+    async create(chain: string, creator: string, name: string, owner: Authority, active: Authority, signatureProvider: SignatureProvider, options?: ConfigOptions): Promise<DIDDocument>;
 
     async resolve(did: string, options?: ConfigOptions): Promise<DIDDocument>;
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,7 +1,7 @@
 import { DIDDocument } from 'did-resolver';
 import { SignatureProvider } from 'eosjs/dist/eosjs-api-interfaces';
 
-export declare type ConfigOptions = {
+export declare type ChainRegistry = {
     [x: string]: {
         chainId: string,
         service: [{
@@ -12,30 +12,15 @@ export declare type ConfigOptions = {
     }
 }
 
-// export declare type ConfigOptions = {
-//     registry?: ChainRegistry,
-//     authorization?: [
-//         {
-//           actor: string,
-//           permission: string,
-//         },
-//     ], 
-//     create?: {
-//         buyrambytes?: {
-//           bytes: number,
-//         },
-//         delegatebw?: {
-//           stakeNetQuantity?: string,
-//           stakeCpuQuantity?: string,
-//           transfer?: boolean,
-//         },
-//     },
-//     config?: {
-//         blocksBehind?: number,
-//         expireSeconds?: number,
-//     },
-//     [x: string]: any
-// }
+export declare type ConfigOptions = {
+    registry?: ChainRegistry,
+    receiverAccount?: sting,
+    creatorPermission?: string,
+    buyrambytes?: number,
+    stakeNetQuantity?: string,
+    stakeCpuQuantity?: string
+    [x: string]: any
+}
 
 export declare type Authority = {
     threshold: number,

--- a/src/update.ts
+++ b/src/update.ts
@@ -1,12 +1,12 @@
-import { DIDDocument } from "did-resolver";
-import { Authority, ConfigOptions } from "./types";
+import { DIDDocument } from 'did-resolver';
+import { Authority, ConfigOptions } from './types';
 
 export default async function update(
-    account: string,
-    permission: string,
-    parent: string,
-    auth: Authority,
-    options?: ConfigOptions): Promise<DIDDocument> {
-
-    return { id: 'did:eosio:stub' };
+  account: string,
+  permission: string,
+  parent: string,
+  auth: Authority,
+  options?: ConfigOptions
+): Promise<DIDDocument> {
+  return { id: 'did:eosio:stub' };
 }

--- a/test/create.test.ts
+++ b/test/create.test.ts
@@ -1,7 +1,3 @@
-
 describe('EOSIO DID Create', async () => {
-
-  it('Create a Jungle DID', async () => {
-  })
-
+  it('Create a Jungle DID', async () => {});
 });

--- a/test/eosioDid.test.ts
+++ b/test/eosioDid.test.ts
@@ -40,3 +40,24 @@ describe('EOSIO DID class', async () => {
     }
   });
 });
+
+/*
+    Just a reminder of how a transaction result looks like.
+{
+    transaction_id: '192ad904a433b69ed35a9ea6a9c3880e8b16629aee26a846024cb0f81389ca1e',
+    processed: {
+      id: '192ad904a433b69ed35a9ea6a9c3880e8b16629aee26a846024cb0f81389ca1e',
+      block_num: 81109622,
+      block_time: '2021-06-03T16:59:06.500',
+      producer_block_id: null,
+      receipt: { status: 'executed', cpu_usage_us: 430, net_usage_words: 42 },
+      elapsed: 430,
+      net_usage: 336,
+      scheduled: false,
+      action_traces: [ [Object], [Object], [Object] ],
+      account_ram_delta: null,
+      except: null,
+      error_code: null
+    }
+}
+ */

--- a/test/eosioDid.test.ts
+++ b/test/eosioDid.test.ts
@@ -1,21 +1,42 @@
 import EosioDID from '../src/index';
 import { Authority } from '../src/types';
+import { RpcError } from 'eosjs';
+import { JsSignatureProvider } from 'eosjs/dist/eosjs-jssig';
+
+const jungleTestKeys = require('../jungleTestKeys.json');
+
+const NEW_ACCOUNT_NAME = 'eosdidtest11';
 
 describe('EOSIO DID class', async () => {
+  it('Create a Jungle DID', async () => {
+    const signatureProvider = new JsSignatureProvider([jungleTestKeys.private]);
 
-    it('Create a Jungle DID', async () => {
+    const eosioDid = new EosioDID();
 
-        const eosioDid = new EosioDID();
-
-        const myKey: Authority = {
-            threshold: 1,
-            keys: [{
-                key: '',
-                weight: 1
-            }]
-        }
-        const didDoc = await eosioDid.create('b1', 'example', myKey, myKey);
-        console.log(didDoc);
-    })
-
+    const myKey: Authority = {
+      threshold: 1,
+      keys: [
+        {
+          key: jungleTestKeys.public,
+          weight: 1,
+        },
+      ],
+      accounts: [],
+      waits: [],
+    };
+    try {
+      const didDoc = await eosioDid.create(
+        'eos:testnet:jungle',
+        jungleTestKeys.name,
+        NEW_ACCOUNT_NAME,
+        myKey,
+        myKey,
+        signatureProvider
+      );
+      console.log(didDoc);
+    } catch (e) {
+      console.log('\nCaught exception: ' + e);
+      if (e instanceof RpcError) console.log(JSON.stringify(e.json, null, 2));
+    }
+  });
 });


### PR DESCRIPTION
This PR addresses issue #1 and #4 (in part) but is meant to discuss some questions I have. The implementation is **not yet finished**.

In order to test the code on the Jungle Testnet, I have created an account, tapped the faucet for some EOS, and staked it for resources. The key material is saved locally to a JSON-file, which I added to the .gitignore. That way the private key never ends up on the repo and others could use custom accounts for testing.

**The test runs fine** and the account gets created 👍 
So far so good.
\
\
But the resulting `DIDDocument` is little more than a placeholder. I was wondering if we should _refactor_ the `createDIDDocument` function from the resolver so both packages can use it and we can maintain the logic in one place.
\
\
_I'm uncertain about validation and error handling:_
Which (if any) inputs should I validate? For now, I just check if the account names and chain id are to spec.

Is the absence of errors enough to know that the transaction went through as planned? Should I check that the `error_code` field is `null` or something like that?
\
\
It seems to me, that we need some **additional parameter** for the function.
Because of that, I changed the function signature:
```js
export default async function create(
  chain: string,
  creator: string,
  name: string,
  owner: Authority,
  active: Authority,
  signatureProvider: SignatureProvider,
  options?: ConfigOptions
): Promise<DIDDocument>
```
The `chain` contains either the chain name or id. The `signatureProvider` holds the private key of the creator.


There are also a few fields of the transaction that a user might want to override. I moved those into an `additionalOptions` object for clarity. 
As far as I understand you have to buy RAM and delegate some CPU and NET for the account creation to work.
```js
const additionalOptions = {
    receiverAccount: 'eosio',  // I don't know if chains can customize this name
    authorization: [
      {
        actor: creator,
        permission: 'active',
      },
    ],
    buyrambytes: {
      bytes: 8192,
    },
    delegatebw: {
      stakeNetQuantity: '1.0000 EOS',
      stakeCpuQuantity: '1.0000 EOS',
      transfer: false,
    },
    config: {
      blocksBehind: 3,
      expireSeconds: 30,
    },
  };
```
Do you think the whole transaction should be somewhat reconfigurable?
Maybe instead of using the `options` parameter solely for custom chain registry entries, we could expand it? 
So the type could look something like this:
```js
export declare type ConfigOptions = {
    registry?: ChainRegistry,
    authorization?: [
        {
          actor: string,
          permission: string,
        },
    ], 
    create?: {
        buyrambytes?: {
          bytes: number,
        },
        delegatebw?: {
          stakeNetQuantity?: string,
          stakeCpuQuantity?: string,
          transfer?: boolean,
        },
    },
    config?: {
        blocksBehind?: number,
        expireSeconds?: number,
    },
    [x: string]: any
}
export declare type ChainRegistry = {
    [x: string]: {
        chainId: string,
        service: [{
            id: string,
            type: string | [string],
            serviceEndpoint: string
        }]
    }
}
```
If we choose to expand the options object, we could also move some or all of the other parameters in there. I'm unclear if this is useful or unnecessary.
\
\
A _small change_ was made to the **type Authority** because NodeEOS threw an error whenever keys and/or waits were not set. So I made them mandatory and allowed for an empty array.
\
\
Finally, I ran `prettier` over the whole project 🥇 
(In reference to PR [#9](https://github.com/Gimly-Blockchain/eosio-did-resolver/pull/9) from the resolver repo)
\
\
**So in summary:**

- [x] Decide how to handle options
- [x] Decide whether to validate inputs before sending the transaction
- [x] Decide whether to validate the transaction result
- [ ] Implement a proper DID document result / refactor `createDIDDocument()`

Any other suggestions or issues?